### PR TITLE
fix: Auth state persistence and UI refinements

### DIFF
--- a/client/src/app/store.js
+++ b/client/src/app/store.js
@@ -3,5 +3,14 @@ import rootReducer from "./rootReducer";
 import { authApi } from "@/features/api/authApi";
 
 export const appStore = configureStore({
-  reducer: rootReducer, middleware: (defaultMiddleware) => defaultMiddleware().concat(authApi.middleware)
+  reducer: rootReducer,
+  middleware: (defaultMiddleware) =>
+    defaultMiddleware().concat(authApi.middleware),
 });
+
+const initializeApp = async () => {
+  await appStore.dispatch(
+    authApi.endpoints.loadUser.initiate({}, { forceRefetch: true })
+  );
+};
+initializeApp();

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import { Menu, School } from "lucide-react";
-import React from "react";
+import React, { useEffect } from "react";
 import { Button } from "./ui/button";
 import {
   DropdownMenu,
@@ -22,10 +22,27 @@ import {
   SheetTrigger,
 } from "./ui/sheet";
 import { Separator } from "@radix-ui/react-dropdown-menu";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { useLogoutUserMutation } from "@/features/api/authApi";
+import { toast } from "sonner";
 
 const Navbar = () => {
   const user = true;
+  const [logoutUser, { data, isSuccess }] = useLogoutUserMutation();
+
+  const navigate = useNavigate();
+
+  const logoutHandler = async () => {
+    await logoutUser();
+    navigate("/login");
+  };
+
+  // Show success message when user logs out
+  useEffect(() => {
+    if (isSuccess) {
+      toast.success(data.message || "User logged out.");
+    }
+  }, [isSuccess]);
 
   return (
     <div className="h-16 dark:bg-[#0A0A0A] bg-white border-b dark:border-b-gray-800 border-b-gray-200 fixed top-0 left-0 right-0 duration-300 z-10">
@@ -58,7 +75,7 @@ const Navbar = () => {
                   <DropdownMenuItem>
                     <Link to="profile">Edit Profile</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem>Log out</DropdownMenuItem>
+                  <DropdownMenuItem onClick={logoutHandler}>Log out</DropdownMenuItem>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem>Dashboard</DropdownMenuItem>

--- a/client/src/features/api/authApi.js
+++ b/client/src/features/api/authApi.js
@@ -34,6 +34,13 @@ export const authApi = createApi({
       },
     }),
 
+    logoutUser: builder.mutation({
+      query: () => ({
+        url: "logout",
+        method: "GET",
+      }),
+    }),
+
     loadUser: builder.query({
       query: () => ({
         url: "profile",
@@ -55,6 +62,7 @@ export const authApi = createApi({
 export const {
   useRegisterUserMutation,
   useLoginUserMutation,
+  useLogoutUserMutation,
   useLoadUserQuery,
   useUpdateUserMutation,
 } = authApi;

--- a/client/src/features/api/authApi.js
+++ b/client/src/features/api/authApi.js
@@ -46,6 +46,14 @@ export const authApi = createApi({
         url: "profile",
         method: "GET",
       }),
+      async onQueryStarted(_, { queryFulfilled, dispatch }) {
+        try {
+          const result = await queryFulfilled;
+          dispatch(userLoggedIn({ user: result.data.user }));
+        } catch (error) {
+          console.log(error);
+        }
+      },
     }),
 
     updateUser: builder.mutation({

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -95,7 +95,7 @@ const Login = () => {
   return (
     <div className="flex items-center w-full justify-center mt-24">
       <div className="flex w-full max-w-sm flex-col gap-6">
-        <Tabs defaultValue="account">
+        <Tabs defaultValue="login">
           <TabsList className="w-full">
             <TabsTrigger value="signup">Signup</TabsTrigger>
             <TabsTrigger value="login">Login</TabsTrigger>

--- a/client/src/pages/student/Profile.jsx
+++ b/client/src/pages/student/Profile.jsx
@@ -62,7 +62,7 @@ const Profile = () => {
   }, [error, updateUserData, isSuccess, isError]);
 
   if (!data || !data.user) return <ProfileSkeleton />;
-  const { user } = data;
+  const user = data && data.user;
 
   const profileIsLoading = isLoading;
 

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -82,7 +82,7 @@ export const logout = async (_, res) => {
     return res
       .status(200)
       .cookie("token", "", { maxAge: 0 })
-      .json({ success: true, message: "Logged out successfully" });
+      .json({ success: true, message: "Logged out successfully." });
   } catch (error) {
     console.log(error);
     return res.status(500).json({


### PR DESCRIPTION
## Changes
- Fixed logout → login navigation
- Persisted user data across reloads
- Set login tab as default
- Safeguarded profile data destructuring

### Testing Checklist
- [x] Logout redirects to /login
- [x] User data persists on reload
- [x] Login tab opens by default
- [x] Profile renders without crashes