### PR TITLE
fix: Navbar loading states and auth hydration

### DIFF
--- a/client/src/app/rootReducer.js
+++ b/client/src/app/rootReducer.js
@@ -4,6 +4,6 @@ import { authApi } from "@/features/api/authApi";
 
 const rootReducer = combineReducers({
   [authApi.reducerPath]: authApi.reducer,
-  authReducer,
+  auth: authReducer,
 });
 export default rootReducer;

--- a/client/src/components/LoadingSpinner.jsx
+++ b/client/src/components/LoadingSpinner.jsx
@@ -1,0 +1,13 @@
+import { Loader } from "lucide-react";
+import React from "react";
+
+const LoadingSpinner = () => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50">
+      <Loader className="animate-spin h-16 w-16 text-blue-600" />
+        <p className="mt-4 text-lg font-semibold text-gray-700">Loading, please wait...</p>
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -25,22 +25,23 @@ import { Separator } from "@radix-ui/react-dropdown-menu";
 import { Link, useNavigate } from "react-router-dom";
 import { useLogoutUserMutation } from "@/features/api/authApi";
 import { toast } from "sonner";
+import { useSelector } from "react-redux";
 
 const Navbar = () => {
-  const user = true;
+  const { user } = useSelector((store) => store.auth || {});
   const [logoutUser, { data, isSuccess }] = useLogoutUserMutation();
 
   const navigate = useNavigate();
 
   const logoutHandler = async () => {
     await logoutUser();
-    navigate("/login");
   };
 
   // Show success message when user logs out
   useEffect(() => {
     if (isSuccess) {
       toast.success(data.message || "User logged out.");
+      navigate("/login");
     }
   }, [isSuccess]);
 
@@ -60,7 +61,7 @@ const Navbar = () => {
               <DropdownMenuTrigger asChild>
                 <Avatar className="rounded-md h-[34px] w-[34px] cursor-pointer">
                   <AvatarImage
-                    src="https://github.com/evilrabbit.png"
+                    src={user?.photoUrl || "https://github.com/evilrabbit.png"}
                     alt="@evilrabbit"
                   />
                   <AvatarFallback>ER</AvatarFallback>
@@ -75,7 +76,9 @@ const Navbar = () => {
                   <DropdownMenuItem>
                     <Link to="profile">Edit Profile</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={logoutHandler}>Log out</DropdownMenuItem>
+                  <DropdownMenuItem onClick={logoutHandler}>
+                    Log out
+                  </DropdownMenuItem>
                 </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem>Dashboard</DropdownMenuItem>
@@ -83,14 +86,14 @@ const Navbar = () => {
             </DropdownMenu>
           ) : (
             <div className="flex items-center gap-2">
-              <Button variant="outline" className="w-[78px]">
+              <Button variant="outline" className="w-[78px] cursor-pointer">
                 Signup
               </Button>
               <Button
                 variant="outline"
-                className="w-[78px] bg-black text-white"
+                className="w-[78px] bg-black text-white cursor-pointer"
               >
-                Login
+                <Link to={"/login"}>Login</Link>
               </Button>
             </div>
           )}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -5,12 +5,21 @@ import App from "./App.jsx";
 import { Provider } from "react-redux";
 import { appStore } from "./app/store";
 import { Toaster } from "./components/ui/sonner";
+import { useLoadUserQuery } from "./features/api/authApi";
+import LoadingSpinner from "./components/LoadingSpinner";
+
+const Custom = ({ children }) => {
+  const { isLoading } = useLoadUserQuery();
+  return <>{isLoading ? <LoadingSpinner/> : <>{children}</>}</>;
+};
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <Provider store={appStore}>
-      <App />
-      <Toaster />
+      <Custom>
+        <App />
+        <Toaster />
+      </Custom>
     </Provider>
   </StrictMode>
 );

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -15,6 +15,8 @@ router.route("/register").post(register);
 router.route("/login").post(login);
 router.route("/logout").get(logout);
 router.route("/profile").get(isAuthenticated, getUserProfile);
-router.route("/profile/update").put(isAuthenticated, upload.single("profilePhoto"),updateProfile);
+router
+  .route("/profile/update")
+  .put(isAuthenticated, upload.single("profilePhoto"), updateProfile);
 
 export default router;


### PR DESCRIPTION
## Changes
- Fixed missing `auth` key in rootReducer  
- Added loading spinner during auth check  
- Safeguarded user data access  
- Formatted route files  

### Testing Checklist
- [x] Navbar shows spinner during auth load  
- [x] Profile photo persists on reload  
- [x] No flash of unauthorized state  