### PR TITLE
Add navbar to login tabs navigation

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -33,6 +33,12 @@ const Navbar = () => {
 
   const navigate = useNavigate();
 
+  // Handle signup click
+  const signupClickHandler = () => {
+    navigate("/login?tab=signup");
+  };
+
+  // Logout user when user clicks on logout button
   const logoutHandler = async () => {
     await logoutUser();
   };
@@ -101,14 +107,14 @@ const Navbar = () => {
             <div className="flex items-center gap-2">
               <Button
                 variant="outline"
-                onClick={() => navigate("/login")}
+                onClick={signupClickHandler}
                 className="w-[78px] cursor-pointer"
               >
                 Signup
               </Button>
               <Button
                 variant="outline"
-                onClick={() => navigate("/login")}
+                onClick={() => navigate("/login?tab=login")}
                 className="w-[78px] bg-black text-white cursor-pointer"
               >
                 Login

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import { AppWindowIcon, CodeIcon, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -18,7 +18,7 @@ import {
   useRegisterUserMutation,
 } from "@/features/api/authApi";
 import { toast } from "sonner";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 const Login = () => {
   const [signupInput, setSignupInput] = useState({
@@ -27,6 +27,17 @@ const Login = () => {
     password: "",
   });
   const [loginInput, setLoginInput] = useState({ email: "", password: "" });
+
+  // open tab on click value (signup / login)
+  const [searchParams] = useSearchParams();
+  const [activeTab, setActiveTab] = useState("login");
+
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    if (tab === "signup" || tab === "login") {
+      setActiveTab(tab);
+    }
+  }, [searchParams]);
 
   const [
     registerUser,
@@ -93,10 +104,14 @@ const Login = () => {
   return (
     <div className="flex items-center w-full justify-center mt-24">
       <div className="flex w-full max-w-sm flex-col gap-6">
-        <Tabs defaultValue="login">
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
           <TabsList className="w-full">
-            <TabsTrigger value="signup">Signup</TabsTrigger>
-            <TabsTrigger value="login">Login</TabsTrigger>
+            <TabsTrigger value="signup" className="cursor-pointer">
+              Signup
+            </TabsTrigger>
+            <TabsTrigger value="login" className={"cursor-pointer"}>
+              Login
+            </TabsTrigger>
           </TabsList>
           <TabsContent value="signup">
             <Card>


### PR DESCRIPTION
## What this PR does
- Implements URL parameter-based tab navigation from navbar to login page
- Users can now click signup/login buttons in navbar and land on the correct tab

## Changes made
- **Navbar.jsx**: Added navigation with URL parameters (?tab=signup/login)
- **Login.jsx**: Added useSearchParams hook to read URL parameters and set active tab
- Replaced defaultValue with controlled state for Tabs component

## Testing
- ✅ Clicking 'Signup' in navbar opens login page with signup tab active
- ✅ Clicking 'Login' in navbar opens login page with login tab active  
- ✅ Direct URL navigation works (e.g., /login?tab=signup)
- ✅ Tab switching within the page still works normally

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Fixes: Navigation issue where signup button always opened login tab